### PR TITLE
take all data rows when ctrl_idx is empty

### DIFF
--- a/R/residuals.R
+++ b/R/residuals.R
@@ -114,10 +114,15 @@ get_residuals <- function(data, features, covars, exposure, id_cols, ctrl_idx=c(
   # Add feature names to residuals
   colnames(resid_tmp) <- features
   # Add sample ID columns to residuals
-  ctrl_names <- data[ctrl_idx,] %>% dplyr::select(all_of(id_cols))
-  case_names <- data[-ctrl_idx,] %>% dplyr::select(all_of(id_cols))
-  names <- rbind(ctrl_names, case_names)
-  resid <- bind_cols(names, resid_tmp)
+  if(length(ctrl_idx) > 0){
+    ctrl_names <- data[ctrl_idx,] %>% dplyr::select(all_of(id_cols))
+    case_names <- data[-ctrl_idx,] %>% dplyr::select(all_of(id_cols))
+    names <- rbind(ctrl_names, case_names)
+    resid <- bind_cols(names, resid_tmp)
+  } else {
+    names <- data %>% dplyr::select(all_of(id_cols))
+    resid <- bind_cols(names, resid_tmp)
+  }
   
   # Merge with original covariates
   final <- merge(resid, data %>% dplyr::select(!all_of(features)), by = id_cols, no.dups = TRUE)

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -75,8 +75,8 @@ get_residuals <- function(data, features, covars, exposure, id_cols, ctrl_idx=c(
   # For each feature, residuals with lm (not using mixed models because not correcting for plate or batch)
   if(parallel){
     # Register parallel backend if needed
-    cl <- makeCluster(cores)
-    registerDoParallel(cl)
+    cl <- parallel::makeCluster(cores)
+    doParallel::registerDoParallel(cl)
     
   } 
   
@@ -111,7 +111,7 @@ get_residuals <- function(data, features, covars, exposure, id_cols, ctrl_idx=c(
     return(res)
   }
   
-  if(parallel){stopCluster(cl)}
+  if(parallel){parallel::stopCluster(cl)}
 
   
   


### PR DESCRIPTION
There is an error due to an empty ctrl_idx input in the get_residuals:

Error in -ctrl_idx : invalid argument to unary operator

At the end of the function:
case_names <- data[-ctrl_idx,] %>% dplyr::select(all_of(id_cols))

I fixed it by adding a condition to take all of the data rows if ctrl_idx is empty.
Please check it this does not mess up the intended output.